### PR TITLE
Added the ability to cache CMake targets by build type.

### DIFF
--- a/cpm/src/internal/codemodel_v2.rs
+++ b/cpm/src/internal/codemodel_v2.rs
@@ -1,0 +1,53 @@
+// use serde_json::Value;
+use serde::{ Deserialize, Serialize };
+use spdlog::prelude::*;
+use std::fs;
+use std::path::{ Path, PathBuf };
+use std::io::{ self, ErrorKind };
+
+use crate::internal::settings::Settings;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CMakeAPIResponse {
+    pub configurations: Vec<Configuration>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Configuration {
+    pub name: String,
+    pub targets: Vec<Target>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Target {
+    pub name: String,
+}
+
+pub fn generate_cmake_codemodel_v2(settings: &Settings) {
+    // Very simple. We need to generate 'codemodel-v2' empty file in <build_dir>/.cmake/api/v1/query
+
+    let build_dir = settings.build_dir.clone();
+    let codemodel_v2_path = Path::new(&build_dir).join(".cmake/api/v1/query/codemodel-v2");
+
+    match fs::create_dir_all(&codemodel_v2_path) {
+        Ok(_) => {
+            info!("Successfully created {}.", codemodel_v2_path.display());
+        }
+        Err(e) => {
+            error!("Error creating 'codemodel-v2' directory: {}", e);
+        }
+    }
+}
+
+pub fn find_codemodel_file(path: &Path) -> io::Result<PathBuf> {
+    let entries = fs
+        ::read_dir(path)?
+        .filter_map(Result::ok)
+        .find(|entry| entry.file_name().to_string_lossy().starts_with("codemodel-v2-"))
+        .map(|entry| entry.path());
+
+    match entries {
+        Some(path) => Ok(path),
+        None => Err(io::Error::new(ErrorKind::NotFound, "No codemodel-v2-*.json file found")),
+    }
+}

--- a/cpm/src/internal/mod.rs
+++ b/cpm/src/internal/mod.rs
@@ -2,3 +2,4 @@ pub mod settings;
 pub mod logger;
 pub mod install;
 pub mod cmd;
+pub mod codemodel_v2;

--- a/cpm/src/internal/settings.rs
+++ b/cpm/src/internal/settings.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     // Cached commands
     pub last_cmake_configuration_command: Vec<String>,
     pub last_command: Vec<String>,
+    // Cached targets
+    pub cmake_targets: Vec<String>,
 }
 
 impl Settings {
@@ -74,6 +76,8 @@ impl Settings {
             // Cached commands
             last_cmake_configuration_command: vec![],
             last_command: vec![],
+            // Cached targets
+            cmake_targets: vec![],
         })
     }
 
@@ -217,7 +221,8 @@ impl Settings {
             | "cmake_system_type"
             | "cmake_build_type"
             | "last_cmake_configuration_command"
-            | "last_command" => true,
+            | "last_command"
+            | "cmake_targets" => true,
             _ => false,
         }
     }


### PR DESCRIPTION
This is achieved by utilizing
[cmake-file-api](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html).

Completing #6 